### PR TITLE
Minor tweaks/enhancements

### DIFF
--- a/HostnameTitleBar/HostnameTitleBar/background.js
+++ b/HostnameTitleBar/HostnameTitleBar/background.js
@@ -5,13 +5,20 @@
 
     function render(template, values) {
         return template.replace(/{([a-z]+?)}/ig, (match, key) => {
-            return values[key] || match;
+            return values[key];
         });
     }
 
     async function setTitle(windowId, tab) {
         try {
             let url = new URL(tab.url);
+            let protocol = url.protocol.replace(':', '');
+            let port = '';
+
+            if (url.port != '') {
+                port = ':' + url.port;
+            }
+
             let values = {
                 title: tab.title,
                 hash: url.hash,
@@ -20,15 +27,14 @@
                 href: url.href,
                 origin: url.origin,
                 pathname: url.pathname,
-                port: url.port,
-                protocol: url.protocol,
+                port: port,
+                protocol: protocol,
                 search: url.search
             }
-
             //A suffix would be nicer but that isn't currently supported.
             let results = await browser.storage.local.get({ template: defaultTemplate });
             let update = { titlePreface: " " }; //For some reason titlePreface = "", null, or undefined doesn't clear it, but spaces seem to get trimmed so this works.
-            if (url && results.template !== "" && ["http:", "https:"].indexOf(url.protocol) !== -1) { //Other protocols?
+            if (url && results.template !== "" && ["http", "https"].indexOf(protocol) !== -1) { //Other protocols?
                 update.titlePreface = render(results.template, values) + " - ";
             }
             await browser.windows.update(windowId, update);

--- a/HostnameTitleBar/HostnameTitleBar/options.html
+++ b/HostnameTitleBar/HostnameTitleBar/options.html
@@ -26,7 +26,7 @@
                 <label>Template Parts (hover to highlight example)</label>
                 <dl class="inline">
                     <dt>Page Title:</dt><dd><span id="part-title">Example Domain</span></dd>
-                    <dt>Page Url:</dt><dd><span id="part-href"><span id="part-origin"><span id="part-protocol">https:</span>//<span id="part-host"><span id="part-hostname">www.example.com</span>:<span id="part-port">8080</span></span></span><span id="part-pathname">/path</span><span id="part-search">?search=1</span><span id="part-hash">#hash</span></span></dd>
+                    <dt>Page Url:</dt><dd><span id="part-href"><span id="part-origin"><span id="part-protocol">https</span>://<span id="part-host"><span id="part-hostname">www.example.com</span><span id="part-port">:8080</span></span></span><span id="part-pathname">/path</span><span id="part-search">?search=1</span><span id="part-hash">#hash</span></span></dd>
                 </dl>
                 <ul class="part-list">
                     <li data-for="part-title"   >{title}</li>

--- a/HostnameTitleBar/HostnameTitleBar/options.js
+++ b/HostnameTitleBar/HostnameTitleBar/options.js
@@ -3,19 +3,7 @@
 
     const defaultTemplate = "{title} - {hostname}"
     const exampleTitle = "Example Domain";
-    const exampleUrl = new URL("https://www.example.com:8080/path?search=1#hash");
-    const exampleValues = {
-        title: exampleTitle,
-        hash: exampleUrl.hash,
-        host: exampleUrl.host,
-        hostname: exampleUrl.hostname,
-        href: exampleUrl.href,
-        origin: exampleUrl.origin,
-        pathname: exampleUrl.pathname,
-        port: exampleUrl.port,
-        protocol: exampleUrl.protocol,
-        search: exampleUrl.search
-    }
+    const exampleUrl = new URL("https://www.example.com:443/path?search=1#hash");
 
     function render(template, values) {
         return template.replace(/{([a-z]+?)}/ig, (match, key) => {
@@ -24,6 +12,26 @@
     }
 
     function preview(template) {
+        let protocol = exampleUrl.protocol.replace(':', '');
+        let port = '';
+
+        if (exampleUrl.port != '') {
+            port = ':' + exampleUrl.port;
+        }
+
+        let exampleValues = {
+            title: exampleTitle,
+            hash: exampleUrl.hash,
+            host: exampleUrl.host,
+            hostname: exampleUrl.hostname,
+            href: exampleUrl.href,
+            origin: exampleUrl.origin,
+            pathname: exampleUrl.pathname,
+            port: port,
+            protocol: protocol,
+            search: exampleUrl.search
+        }
+
         document.getElementById("preview").value = render(template + (template !== "" ? " - " : "") + "{title} - Mozilla Firefox", exampleValues);
     }
 


### PR DESCRIPTION
Hello,

Thanks for writing this extension!

I recently migrated from Chromium to Firefox and needed something that could replicate what [Url in title](https://chrome.google.com/webstore/detail/url-in-title/ignpacbgnbnkaiooknalneoeladjnfgb) does. This extension fit the bill but had a few difference which this PR ports over.

1. Null template variables will still return instead of treating the variable as non-existent. 
2. If port has a value then it will prepend a colon. Otherwise null is returned.
3. Removes the colon from the protocol.
